### PR TITLE
Bug fix for add (prepend) and remove

### DIFF
--- a/src/jquery.cycle2.command.js
+++ b/src/jquery.cycle2.command.js
@@ -155,12 +155,11 @@ $.extend( c2.API, {
             opts.slides = $( slides );
             opts.slideCount--;
             $( slideToRemove ).remove();
-            if (index == opts.currSlide)
+            if ( index == opts.currSlide ) {
+				opts.nextSlide = opts.currSlide--;
                 opts.API.advanceSlide( 1 );
-            else if ( index < opts.currSlide )
-                opts.currSlide--;
-            else
-                opts.currSlide++;
+            } else if ( index < opts.currSlide )
+                opts.nextSlide = opts.currSlide--;
 
             opts.API.trigger('cycle-slide-removed', [ opts, index, slideToRemove ]).log('cycle-slide-removed');
             opts.API.updateView();

--- a/src/jquery.cycle2.core.js
+++ b/src/jquery.cycle2.core.js
@@ -214,9 +214,14 @@ $.fn.cycle.API = {
             opts.slideCount++;
             slideOpts = opts.API.buildSlideOpts( slide );
 
-            if ( prepend )
+            if ( prepend ) {
                 opts.slides = $( slide ).add( opts.slides );
-            else
+                opts.currSlide++;
+                opts.nextSlide++; 
+
+                if ( opts.nextSlide >= opts.slideCount )
+                    opts.nextSlide -= opts.slideCount;
+            } else
                 opts.slides = opts.slides.add( slide );
 
             opts.API.initSlide( slideOpts, slide, --opts._maxZ );


### PR DESCRIPTION
When prepending, currSlide and nextSlide needs to be incremented.

When removing previous or current slide, we need to move back one slide.
And there's no need to increment currSlide when removing a slide that's
after the current slide.